### PR TITLE
feat: create temporary CI files in top-level directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 example-payload.json
 .DS_Store
 .env
+ci-jobs

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,11 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+export default {
   preset: "ts-jest",
   testEnvironment: "node",
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+  extensionsToTreatAsEsm: [".ts"],
+  globals: {
+    "ts-jest": {
+      useESM: true,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "watch": "npx tsc -w",
     "start": "node --experimental-vm-modules --experimental-specifier-resolution=node dist/index.js",
-    "test": "npx --experimental-vm-modules jest"
+    "test": "npx --experimental-vm-modules --experimental-specifier-resolution=node jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "description": "CI Server",
   "main": "src/index.js",
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "watch": "npx tsc -w",
-    "start": "node dist/index.js",
+    "start": "node --experimental-vm-modules --experimental-specifier-resolution=node dist/index.js",
     "test": "npx --experimental-vm-modules jest"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import path from "path";
+import { getRootDirectory } from "./pkg/file";
 import {
   createJobDirectory,
   cloneRepository,
@@ -13,7 +15,10 @@ import {
 } from "./pkg/commit_check";
 import { PORT, JOB_FILE_DIR } from "./constants/constants";
 
+// initialize app
 const app = express();
+
+// use bodyParser middleware to parse JSON
 app.use(bodyParser.json());
 
 app.post("/run", async (req: Request, res: Response) => {
@@ -32,7 +37,10 @@ app.post("/run", async (req: Request, res: Response) => {
     repositoryName,
     commitHash
   );
-  const jobDirectory = `${JOB_FILE_DIR}/${ownerName}-${repositoryName}-${commitHash}`;
+  const jobDirectory = path.join(
+    getRootDirectory(),
+    `${JOB_FILE_DIR}/${ownerName}-${repositoryName}-${commitHash}`
+  );
 
   // Set CI commit status to "pending"
   await setPendingCommitStatus(commitStatusURL);

--- a/src/pkg/ci.ts
+++ b/src/pkg/ci.ts
@@ -6,47 +6,48 @@ import { executeAndLogCommand } from "./io";
 
 /**
  * Creates a parent- (if not existing) and job-directory
- * 
+ *
  * @param jobDirectory the relative path of the directory to create
  */
 export const createJobDirectory = (jobDirectory: string) => {
   const createDirsCommand = `mkdir -p "${jobDirectory}"`;
   executeAndLogCommand(createDirsCommand, CMD_EXEC_OPTIONS);
-}
+};
 
 /**
  * Clones repository into the specified directory
- * 
+ *
  * @param sshURL the SSH URL of the git repository to clone
  * @param branchRef the reference name of the branch to clone
  * @param intoDirectory the directory to clone the repository into
  */
-export const cloneRepository = (sshURL: string, branchRef: string, intoDirectory: string) => {
+export const cloneRepository = (
+  sshURL: string,
+  branchRef: string,
+  intoDirectory: string
+) => {
   const branch = branchRef.substring("refs/heads/".length);
   const cloneCommand = `git clone ${sshURL} . --branch ${branch}`;
   executeAndLogCommand(cloneCommand, CMD_EXEC_OPTIONS, intoDirectory);
-}
+};
 
 /**
  * Reads the CI config file and returns its contents
- * 
+ *
  * @param jobDirectory the path to the directory of the CI job
  * @returns the CI config file, or null if it did not exist
  */
 export const getRepositoryConfig = async (jobDirectory: string) => {
-  const absoluteJobDirectory = path.resolve(__dirname, jobDirectory);
-  const configFilePath = path.join(absoluteJobDirectory, CI_FILE_NAME);
+  const configFilePath = path.join(jobDirectory, CI_FILE_NAME);
   const ciConfigFileBuffer = await readFile(configFilePath);
   if (!ciConfigFileBuffer) return null;
 
-  const config: CIConfig = JSON.parse(
-    ciConfigFileBuffer.toString()
-  );
-  return config
-}
+  const config: CIConfig = JSON.parse(ciConfigFileBuffer.toString());
+  return config;
+};
 
 /**
- * 
+ *
  */
 export const runCISteps = (steps: string[], workingDirectory: string) => {
   let succeeded = true;
@@ -54,4 +55,4 @@ export const runCISteps = (steps: string[], workingDirectory: string) => {
     executeAndLogCommand(step, CMD_EXEC_OPTIONS, workingDirectory);
   }
   return succeeded;
-}
+};

--- a/src/pkg/file.ts
+++ b/src/pkg/file.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Gets the root absolute path of the project
+ * @returns the root path of the project
+ */
+export const getRootDirectory = () => {
+  return join(__dirname, "../../");
+};

--- a/src/pkg/io.ts
+++ b/src/pkg/io.ts
@@ -11,7 +11,7 @@ export const executeAndLogCommand = (
   try {
     execSync(command, {
       stdio: commandOptions,
-      cwd: path.resolve(__dirname, cwd),
+      cwd,
     });
     console.log(`done: ${command}`);
   } catch (err) {

--- a/src/pkg/io.ts
+++ b/src/pkg/io.ts
@@ -1,4 +1,8 @@
-import { execSync, SpawnSyncReturns } from "child_process";
+import {
+  execSync,
+  ExecSyncOptionsWithBufferEncoding,
+  SpawnSyncReturns,
+} from "child_process";
 import path from "path";
 
 // TODO: add logging to stdout as well as
@@ -9,15 +13,19 @@ export const executeAndLogCommand = (
 ) => {
   let succeeded = true;
   try {
-    execSync(command, {
+    let execOptions: ExecSyncOptionsWithBufferEncoding = {
       stdio: commandOptions,
-      cwd,
-    });
+    };
+    if (cwd.length > 0) {
+      execOptions = { ...execOptions, cwd };
+    }
+    execSync(command, execOptions);
     console.log(`done: ${command}`);
   } catch (err) {
     const error = err as SpawnSyncReturns<string | Buffer>;
     succeeded = false;
     console.log(`error: ${error.stdout}`);
+    console.log(err);
   }
   return succeeded;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
@@ -22,7 +26,7 @@
     // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-
+ 
     /* Modules */
     "module": "esnext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
@@ -31,7 +35,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+     "types": ["node", "jest"],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "resolveJsonModule": true,                        /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */


### PR DESCRIPTION
Closes #10 

Creates these files:
- Cloned repositories to run CI steps on

in a top-level `ci-jobs` directory, instead of the current working directory (where the server executable is run).